### PR TITLE
0.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 
 /*.egg-info
 /.mypy_cache
+/.pytest_cache
 /.venv
 /build
 /dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ __pycache__
 /build
 /dist
 /doc
-/schema.json

--- a/README.md
+++ b/README.md
@@ -38,13 +38,22 @@ Note: use the environment variable `CTF=/path/to/ctf` if the command is not bein
 
 Have a look at the [sample](./sample) CTF for the structure of a CTF package.
 
+## 📔 Documentation
+
+```
+ctf doc
+```
+
+Provides the [JSON schema](https://json-schema.org/) for `challenge.json`. This is automatically generated from [schema.py](ctf_builder/schema.py).
+
 ## 🎨 Schema
 
 ```
 ctf schema
 ```
 
-Provides the [JSON schema](https://json-schema.org/) for `challenge.json`. This is automatically generated from [schema.py](ctf_builder/schema.py).
+Validates `challenge.json`. Provides what type is expected and a useful comment for fields.
+
 
 ## 🔨 Build
 

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,5 @@
 from ctf_builder.cli import cli
 
+
 if __name__ == "__main__":
     exit(cli())

--- a/ctf_builder/build/__init__.py
+++ b/ctf_builder/build/__init__.py
@@ -1,8 +1,0 @@
-from .args import BuildArgs
-from .attachment import BuildAttachment
-from .builder import BuildBuilder, BuildContext
-from .deployer import BuildDeployer, DeployContext
-from .file_map import BuildFileMap
-from .flag import BuildFlag
-from .tester import BuildTester, TestContext
-from .translation import BuildTranslation

--- a/ctf_builder/build/args.py
+++ b/ctf_builder/build/args.py
@@ -11,7 +11,7 @@ T = typing.TypeVar("T", bound=Args)
 
 class BuildArgs(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: Args) -> typing.Type["BuildArgs"]:
+    def get(cls, obj: Args) -> typing.Type["BuildArgs[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod

--- a/ctf_builder/build/attachment.py
+++ b/ctf_builder/build/attachment.py
@@ -15,7 +15,7 @@ T = typing.TypeVar("T", bound=Attachment)
 
 class BuildAttachment(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: Attachment) -> typing.Type["BuildAttachment"]:
+    def get(cls, obj: Attachment) -> typing.Type["BuildAttachment[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod

--- a/ctf_builder/build/builder.py
+++ b/ctf_builder/build/builder.py
@@ -28,7 +28,7 @@ class BuildContext:
 
 class BuildBuilder(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: T) -> typing.Type["BuildBuilder"]:
+    def get(cls, obj: T) -> typing.Type["BuildBuilder[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod

--- a/ctf_builder/build/deployer.py
+++ b/ctf_builder/build/deployer.py
@@ -38,7 +38,7 @@ class DeployContext:
 
 class BuildDeployer(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: Deployer) -> typing.Type["BuildDeployer"]:
+    def get(cls, obj: Deployer) -> typing.Type["BuildDeployer[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod
@@ -105,8 +105,8 @@ class BuildDeployerDocker(BuildDeployer[DeployerDocker]):
         except:
             return False
 
-        status = container.status
-        health = container.health
+        status: str = container.status
+        health: str = container.health
 
         return status == "running" and health == "healthy"
 

--- a/ctf_builder/build/tester.py
+++ b/ctf_builder/build/tester.py
@@ -33,7 +33,7 @@ class TestContext:
 
 class BuildTester(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: Tester) -> typing.Type["BuildTester"]:
+    def get(cls, obj: Tester) -> typing.Type["BuildTester[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod
@@ -56,7 +56,7 @@ class DockerTestContext:
     errors: typing.List[TestError]
 
 
-def docker_test(context: DockerTestContext):
+def docker_test(context: DockerTestContext) -> None:
     error = None
     try:
         context.docker_client.containers.run(

--- a/ctf_builder/build/translation.py
+++ b/ctf_builder/build/translation.py
@@ -11,7 +11,7 @@ T = typing.TypeVar("T", bound=Translation)
 
 class BuildTranslation(typing.Generic[T], abc.ABC):
     @classmethod
-    def get(cls, obj: Translation) -> typing.Type["BuildTranslation"]:
+    def get(cls, obj: Translation) -> typing.Type["BuildTranslation[typing.Any]"]:
         return subclass_get(cls, obj)
 
     @classmethod

--- a/ctf_builder/cli.py
+++ b/ctf_builder/cli.py
@@ -86,10 +86,15 @@ def cli() -> int:
     end = time.time()
 
     delta = end - start
+    delta_str = f"{delta:.2f}s"
 
     if is_ok:
-        console.print(f"[bold green]OK[/] in [bold green]{delta:.2f} s[/]")
+        console.print(
+            "[bold green]OK[/]", "in", f"[green]{delta_str}[/]", highlight=False
+        )
     else:
-        console.print(f"[bold red]ERROR[/] in [bold red]{delta:.2f} s[/]")
+        console.print(
+            "[bold red]ERROR[/]", "in", f"[red]{delta_str}[/]", highlight=False
+        )
 
     return 0 if is_ok else 1

--- a/ctf_builder/cli.py
+++ b/ctf_builder/cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import os.path
 import time
+import typing
 
 import docker
 import rich.console
@@ -11,18 +12,18 @@ from .cmd.common import CliContext
 
 
 def build_command(
-    subparser: argparse._SubParsersAction,
+    subparser: argparse._SubParsersAction[typing.Any],
     name: str,
     command: Command,
     root_directory: str,
-):
+) -> None:
     parser = subparser.add_parser(name=name, help=command.help)
     command.args(parser, root_directory)
 
 
 def build_menu(
     parser: argparse.ArgumentParser, menu: Menu, root_directory: str, depth: int = 0
-):
+) -> None:
     subparser = parser.add_subparsers(dest=f"_{depth}", required=True)
 
     for option_name, option in menu.options.items():
@@ -37,7 +38,9 @@ def build_menu(
             )
 
 
-def run_menu(args, menu: Menu, cli_context: CliContext, depth: int = 0) -> bool:
+def run_menu(
+    args: typing.Any, menu: Menu, cli_context: CliContext, depth: int = 0
+) -> bool:
     target = getattr(args, f"_{depth}")
 
     option = menu.options.get(target)

--- a/ctf_builder/cmd/build.py
+++ b/ctf_builder/cmd/build.py
@@ -7,7 +7,7 @@ import typing
 
 import docker
 
-from ..build import BuildBuilder, BuildContext
+from ..build.builder import BuildBuilder, BuildContext
 from ..error import LibError, SkipError
 from ..schema import Track
 

--- a/ctf_builder/cmd/build.py
+++ b/ctf_builder/cmd/build.py
@@ -16,7 +16,7 @@ from .common import cli_challenge_wrapper, WrapContext, CliContext
 
 @dataclasses.dataclass(frozen=True)
 class Args:
-    challenge: typing.Sequence[str]
+    challenge: typing.Sequence[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/build.py
+++ b/ctf_builder/cmd/build.py
@@ -10,8 +10,7 @@ import docker
 from ..build.builder import BuildBuilder, BuildContext
 from ..error import LibError, SkipError
 from ..schema import Track
-
-from .common import cli_challenge_wrapper, WrapContext, CliContext
+from .common import CliContext, WrapContext, cli_challenge_wrapper
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/cli.py
+++ b/ctf_builder/cmd/cli.py
@@ -2,29 +2,17 @@ import argparse
 import dataclasses
 import typing
 
-from .build import cli as build_cli
-from .build import cli_args as build_args
-
-from .start import cli as start_cli
-from .start import cli_args as start_args
-
-from .stop import cli as stop_cli
-from .stop import cli_args as stop_args
-
-from .schema import cli as schema_cli
-from .schema import cli_args as schema_args
-
-from .test import cli as test_cli
-from .test import cli_args as test_args
-
-from .ctfd.challenges import cli as ctfd_challenges_cli
-from .ctfd.challenges import cli_args as ctfd_challenges_args
-
-from .ctfd.setup import cli as ctfd_setup_cli
-from .ctfd.setup import cli_args as ctfd_setup_args
-
-from .ctfd.teams import cli as ctfd_teams_cli
-from .ctfd.teams import cli_args as ctfd_teams_args
+from .build import cli as build_cli, cli_args as build_args
+from .start import cli as start_cli, cli_args as start_args
+from .stop import cli as stop_cli, cli_args as stop_args
+from .schema import cli as schema_cli, cli_args as schema_args
+from .test import cli as test_cli, cli_args as test_args
+from .ctfd.challenges import (
+    cli as ctfd_challenges_cli,
+    cli_args as ctfd_challenges_args,
+)
+from .ctfd.setup import cli as ctfd_setup_cli, cli_args as ctfd_setup_args
+from .ctfd.teams import cli as ctfd_teams_cli, cli_args as ctfd_teams_args
 
 from .common import CliContext
 

--- a/ctf_builder/cmd/cli.py
+++ b/ctf_builder/cmd/cli.py
@@ -3,6 +3,7 @@ import dataclasses
 import typing
 
 from .build import cli as build_cli, cli_args as build_args
+from .documentation import cli as documentation_cli, cli_args as documentation_args
 from .start import cli as start_cli, cli_args as start_args
 from .stop import cli as stop_cli, cli_args as stop_args
 from .schema import cli as schema_cli, cli_args as schema_args
@@ -36,9 +37,14 @@ CLI = Menu(
     help="Main",
     options={
         "build": Command(help="Build static files", args=build_args, cli=build_cli),
+        "doc": Command(
+            help="Build JSON schemas", args=documentation_args, cli=documentation_cli
+        ),
         "start": Command(help="Start challenges", args=start_args, cli=start_cli),
         "stop": Command(help="Stop challenges", args=stop_args, cli=stop_cli),
-        "schema": Command(help="Build JSON schemas", args=schema_args, cli=schema_cli),
+        "schema": Command(
+            help="Validate challenge.json", args=schema_args, cli=schema_cli
+        ),
         "test": Command(help="Test challenges", args=test_args, cli=test_cli),
         "ctfd": Menu(
             help="CTFd integration",

--- a/ctf_builder/cmd/cli.py
+++ b/ctf_builder/cmd/cli.py
@@ -2,20 +2,25 @@ import argparse
 import dataclasses
 import typing
 
-from .build import cli as build_cli, cli_args as build_args
-from .documentation import cli as documentation_cli, cli_args as documentation_args
-from .start import cli as start_cli, cli_args as start_args
-from .stop import cli as stop_cli, cli_args as stop_args
-from .schema import cli as schema_cli, cli_args as schema_args
-from .test import cli as test_cli, cli_args as test_args
-from .ctfd.challenges import (
-    cli as ctfd_challenges_cli,
-    cli_args as ctfd_challenges_args,
-)
-from .ctfd.setup import cli as ctfd_setup_cli, cli_args as ctfd_setup_args
-from .ctfd.teams import cli as ctfd_teams_cli, cli_args as ctfd_teams_args
-
+from .build import cli as build_cli
+from .build import cli_args as build_args
 from .common import CliContext
+from .ctfd.challenges import cli as ctfd_challenges_cli
+from .ctfd.challenges import cli_args as ctfd_challenges_args
+from .ctfd.setup import cli as ctfd_setup_cli
+from .ctfd.setup import cli_args as ctfd_setup_args
+from .ctfd.teams import cli as ctfd_teams_cli
+from .ctfd.teams import cli_args as ctfd_teams_args
+from .documentation import cli as documentation_cli
+from .documentation import cli_args as documentation_args
+from .schema import cli as schema_cli
+from .schema import cli_args as schema_args
+from .start import cli as start_cli
+from .start import cli_args as start_args
+from .stop import cli as stop_cli
+from .stop import cli_args as stop_args
+from .test import cli as test_cli
+from .test import cli_args as test_args
 
 
 @dataclasses.dataclass

--- a/ctf_builder/cmd/common.py
+++ b/ctf_builder/cmd/common.py
@@ -9,14 +9,14 @@ import typing
 import docker
 import docker.errors
 import docker.models.networks
-
 import rich.console
 import rich.progress
 
 from ..config import CHALLENGE_MAX_PORTS
-from ..error import BuildError, LibError, SkipError, print_errors, get_exit_status
+from ..error import BuildError, LibError, SkipError, get_exit_status, print_errors
 from ..parse import parse_track
-from ..schema import Track, PortProtocol
+from ..schema import PortProtocol, Track
+
 
 MAX_TCP_PORT = 65_535
 

--- a/ctf_builder/cmd/common.py
+++ b/ctf_builder/cmd/common.py
@@ -52,19 +52,6 @@ def port_generator(port: int) -> typing.Generator[typing.Optional[int], None, No
         yield None
 
 
-def get_network(
-    client: docker.DockerClient, name: typing.Optional[str] = None
-) -> typing.Optional[docker.models.networks.Network]:
-    try:
-        return client.networks.get(name)
-    except docker.errors.NotFound:
-        pass
-    except docker.errors.APIError:
-        pass
-
-    return None
-
-
 def build_connection_string(
     host: str, port: int, protocol: PortProtocol, path: typing.Optional[str] = None
 ) -> str:
@@ -80,6 +67,28 @@ def build_connection_string(
     assert False, f"unhandled {protocol}"
 
 
+def get_network(
+    client: docker.DockerClient, name: typing.Optional[str] = None
+) -> typing.Optional[docker.models.networks.Network]:
+    try:
+        return client.networks.get(name)
+    except docker.errors.NotFound:
+        pass
+    except docker.errors.APIError:
+        pass
+
+    return None
+
+
+def create_network(
+    client: docker.DockerClient, name: typing.Optional[str] = None
+) -> typing.Optional[docker.models.networks.Network]:
+    try:
+        return client.networks.create(name, driver="bridge")
+    except docker.errors.APIError:
+        return None
+
+
 def get_create_network(
     client: docker.DockerClient, name: typing.Optional[str] = None
 ) -> typing.Optional[docker.models.networks.Network]:
@@ -87,12 +96,7 @@ def get_create_network(
     if network is not None:
         return network
 
-    try:
-        return client.networks.create(name, driver="bridge")
-    except docker.errors.APIError:
-        pass
-
-    return None
+    return create_network(client, name)
 
 
 def get_challenges(root_directory: str) -> typing.Optional[typing.Sequence[str]]:

--- a/ctf_builder/cmd/ctfd/challenges.py
+++ b/ctf_builder/cmd/ctfd/challenges.py
@@ -9,18 +9,16 @@ from ...build.attachment import BuildAttachment
 from ...build.deployer import BuildDeployer
 from ...build.flag import BuildFlag
 from ...build.translation import BuildTranslation
-from ...config import CHALLENGE_BASE_PORT, CHALLENGE_MAX_PORTS, CHALLENGE_HOST
+from ...config import CHALLENGE_BASE_PORT, CHALLENGE_HOST, CHALLENGE_MAX_PORTS
 from ...ctfd import CTFdAPI
-from ...error import LibError, BuildError, DeployError
+from ...error import BuildError, DeployError, LibError
 from ...schema import Track, Translation
-
-from ..common import CliContext
-
 from ..common import (
+    CliContext,
     WrapContext,
+    build_connection_string,
     cli_challenge_wrapper,
     get_challenge_index,
-    build_connection_string,
 )
 
 

--- a/ctf_builder/cmd/ctfd/challenges.py
+++ b/ctf_builder/cmd/ctfd/challenges.py
@@ -5,7 +5,10 @@ import os
 import os.path
 import typing
 
-from ...build import BuildTranslation, BuildDeployer, BuildFlag, BuildAttachment
+from ...build.attachment import BuildAttachment
+from ...build.deployer import BuildDeployer
+from ...build.flag import BuildFlag
+from ...build.translation import BuildTranslation
 from ...config import CHALLENGE_BASE_PORT, CHALLENGE_MAX_PORTS, CHALLENGE_HOST
 from ...ctfd import CTFdAPI
 from ...error import LibError, BuildError, DeployError
@@ -377,7 +380,7 @@ def deploy_challenge(track: Track, context: Context) -> typing.Sequence[LibError
     return all_errors
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     challenge_directory = os.path.join(root_directory, "challenges")
 
     challenges = [file for file in glob.glob("*", root_dir=challenge_directory)]

--- a/ctf_builder/cmd/ctfd/challenges.py
+++ b/ctf_builder/cmd/ctfd/challenges.py
@@ -25,9 +25,9 @@ from ..common import (
 @dataclasses.dataclass(frozen=True)
 class Args:
     api_key: str
-    url: str
-    port: int
-    challenge: typing.Sequence[str]
+    url: str = dataclasses.field(default="http://localhost:8000")
+    port: int = dataclasses.field(default=CHALLENGE_BASE_PORT)
+    challenge: typing.Sequence[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/ctfd/setup.py
+++ b/ctf_builder/cmd/ctfd/setup.py
@@ -15,10 +15,10 @@ from ..common import CliContext
 @dataclasses.dataclass
 class Args:
     password: str
-    url: str
     name: str
     email: str
     file: str
+    url: str = dataclasses.field(default="http://localhost:8000")
 
 
 @dataclasses.dataclass

--- a/ctf_builder/cmd/ctfd/setup.py
+++ b/ctf_builder/cmd/ctfd/setup.py
@@ -1,14 +1,13 @@
 import argparse
 import dataclasses
-import os.path
 import json
+import os.path
 import typing
 
 import requests
 
 from ...ctfd import read_nonce
-from ...error import LibError, DeployError, print_errors, get_exit_status
-
+from ...error import DeployError, LibError, get_exit_status, print_errors
 from ..common import CliContext
 
 

--- a/ctf_builder/cmd/ctfd/setup.py
+++ b/ctf_builder/cmd/ctfd/setup.py
@@ -152,14 +152,14 @@ def setup(context: Context) -> typing.Sequence[LibError]:
             DeployError(
                 context="setup",
                 msg="failed to deploy",
-                error=ValueError(res["message"]),
+                error=ValueError(res.json()["message"]),
             )
         ]
 
     return []
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     parser.add_argument(
         "-p", "--password", help="Admin account password", required=True
     )

--- a/ctf_builder/cmd/ctfd/teams.py
+++ b/ctf_builder/cmd/ctfd/teams.py
@@ -36,7 +36,7 @@ class User:
     verified: bool = dataclasses.field(default=True)
 
     @classmethod
-    def from_dict(cls, data: typing.Dict) -> "User":
+    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> "User":
         fields = {}
 
         for field in dataclasses.fields(cls):
@@ -48,14 +48,14 @@ class User:
 
         return cls(**fields)
 
-    def to_api(self) -> typing.Dict:
+    def to_api(self) -> typing.Dict[str, typing.Any]:
         d = self.to_dict()
 
         del d["id"]
 
         return d
 
-    def to_dict(self) -> typing.Dict:
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
         out = {}
 
         for field in dataclasses.fields(User):
@@ -75,7 +75,7 @@ class Team:
     users: typing.Sequence[User] = dataclasses.field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: typing.Dict) -> "Team":
+    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> "Team":
         fields = {}
 
         for field in dataclasses.fields(cls):
@@ -89,7 +89,7 @@ class Team:
 
         return cls(**fields)
 
-    def to_api(self) -> typing.Dict:
+    def to_api(self) -> typing.Dict[str, typing.Any]:
         d = self.to_dict()
 
         del d["id"]
@@ -97,7 +97,7 @@ class Team:
 
         return d
 
-    def to_dict(self) -> typing.Dict:
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
         out = {}
 
         for field in dataclasses.fields(Team):
@@ -188,7 +188,7 @@ def deploy_team(team: Team, context: Context) -> typing.Sequence[LibError]:
     return errors
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     parser.add_argument("-k", "--api_key", help="API Key", required=True)
     parser.add_argument(
         "-u", "--url", help="URL for CTFd", default="http://localhost:8000"

--- a/ctf_builder/cmd/ctfd/teams.py
+++ b/ctf_builder/cmd/ctfd/teams.py
@@ -6,8 +6,7 @@ import typing
 import uuid
 
 from ...ctfd import CTFdAPI
-from ...error import LibError, DeployError, print_errors, get_exit_status
-
+from ...error import DeployError, LibError, get_exit_status, print_errors
 from ..common import CliContext
 
 

--- a/ctf_builder/cmd/ctfd/teams.py
+++ b/ctf_builder/cmd/ctfd/teams.py
@@ -15,7 +15,7 @@ from ..common import CliContext
 class Args:
     api_key: str
     file: str
-    output: str
+    output: typing.Union[str, typing.TextIO]
     url: str = dataclasses.field(default="http://localhost:8000")
 
 
@@ -214,7 +214,7 @@ def cli(args: Args, cli_context: CliContext) -> bool:
 
     all_errors: typing.List[LibError] = []
 
-    out: typing.List[Team] = []
+    out_teams: typing.List[Team] = []
     for team in teams:
         errors = deploy_team(team, context)
         all_errors += errors
@@ -226,12 +226,16 @@ def cli(args: Args, cli_context: CliContext) -> bool:
         )
 
         if not errors:
-            out.append(team)
+            out_teams.append(team)
 
     if cli_context.console:
         cli_context.console.print()
 
-    with open(args.output, "w") as h:
-        json.dump([team.to_dict() for team in out], h, indent=2)
+    out_json = [team.to_dict() for team in out_teams]
+    if isinstance(args.output, str):
+        with open(args.output, "w") as h:
+            json.dump(out_json, h, indent=2)
+    else:
+        json.dump(out_json, args.output, indent=2)
 
     return get_exit_status(all_errors)

--- a/ctf_builder/cmd/ctfd/teams.py
+++ b/ctf_builder/cmd/ctfd/teams.py
@@ -15,9 +15,9 @@ from ..common import CliContext
 @dataclasses.dataclass(frozen=True)
 class Args:
     api_key: str
-    url: str
     file: str
     output: str
+    url: str = dataclasses.field(default="http://localhost:8000")
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/documentation.py
+++ b/ctf_builder/cmd/documentation.py
@@ -1,0 +1,115 @@
+import abc
+import argparse
+import dataclasses
+import enum
+import json
+import os
+import os.path
+import typing
+
+from ..config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
+from ..schema import Track, Path
+
+from .common import CliContext
+
+ATOM_TYPES = {str: "string", int: "integer", float: "number", bool: "boolean"}
+
+
+@dataclasses.dataclass(frozen=True)
+class Args:
+    output: str
+
+
+def is_optional(ptype: typing.Type):
+    origin = typing.get_origin(ptype)
+    args = typing.get_args(ptype)
+
+    return origin == typing.Union and len(args) == 2 and args[1] == type(None)
+
+
+def document_type(
+    ptype: typing.Type, description: typing.Optional[str] = None
+) -> typing.Dict[str, typing.Any]:
+    origin = typing.get_origin(ptype)
+    args = typing.get_args(ptype)
+
+    out: typing.Dict[str, typing.Any]
+    if is_optional(ptype):
+        return document_type(args[0], description)
+    elif origin == dict:
+        out = {
+            "type": "object",
+            "patternProperties": {"^[a-zA-Z0-9_]+$": document_type(args[1])},
+        }
+    elif origin == list:
+        out = {"type": "array", "items": document_type(args[0])}
+    elif ptype in ATOM_TYPES:
+        out = {"type": ATOM_TYPES[ptype]}
+    elif ptype.__base__ == abc.ABC:
+        subclasses = ptype.__subclasses__()
+        values = [document_type(subclass) for subclass in subclasses]
+
+        for subclass, obj in zip(subclasses, values):
+            name = subclass.__name__[len(ptype.__name__) :].lower()
+
+            obj["required"] = [CLASS_TYPE_FIELD, *obj["required"]]
+            obj["properties"] = {
+                CLASS_TYPE_FIELD: {
+                    "description": CLASS_TYPE_COMMENT,
+                    "type": "string",
+                    "enum": [name],
+                },
+                **obj["properties"],
+            }
+
+        out = {"type": "object", "oneOf": values}
+    elif ptype.__base__ == Path:
+        out = {
+            "type": "string",
+        }
+    elif ptype.__base__ == enum.Enum:
+        out = {"type": "string", "enum": [e.value for e in ptype]}
+    else:
+        properties = {}
+        required = []
+        for field in dataclasses.fields(ptype):
+            if (
+                not is_optional(field.type)
+                and isinstance(field.default, dataclasses._MISSING_TYPE)
+                and isinstance(field.default_factory, dataclasses._MISSING_TYPE)
+            ):
+                required.append(field.name)
+
+            properties[field.name] = document_type(
+                field.type, field.metadata.get(COMMENT_FIELD_NAME)
+            )
+
+        out = {"type": "object", "required": required, "properties": properties}
+
+    if description is not None:
+        out = {"description": description, **out}
+
+    return out
+
+
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output directory",
+        default=os.path.join(root_directory, "doc"),
+    )
+
+
+def cli(args: Args, cli_context: CliContext) -> bool:
+    if not os.path.isdir(os.path.dirname(args.output)):
+        return False
+
+    os.makedirs(args.output, exist_ok=True)
+
+    challenge_json = os.path.join(args.output, "challenge.json")
+
+    with open(challenge_json, "w") as h:
+        json.dump(document_type(Track), h, indent=2)
+
+    return True

--- a/ctf_builder/cmd/documentation.py
+++ b/ctf_builder/cmd/documentation.py
@@ -7,10 +7,10 @@ import os
 import os.path
 import typing
 
-from ..config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
-from ..schema import Track, Path
-
+from ..config import CLASS_TYPE_COMMENT, CLASS_TYPE_FIELD, COMMENT_FIELD_NAME
+from ..schema import Path, Track
 from .common import CliContext
+
 
 ATOM_TYPES = {str: "string", int: "integer", float: "number", bool: "boolean"}
 

--- a/ctf_builder/cmd/documentation.py
+++ b/ctf_builder/cmd/documentation.py
@@ -20,7 +20,7 @@ class Args:
     output: str
 
 
-def is_optional(ptype: typing.Type):
+def is_optional(ptype: typing.Type[typing.Any]) -> bool:
     origin = typing.get_origin(ptype)
     args = typing.get_args(ptype)
 
@@ -28,7 +28,7 @@ def is_optional(ptype: typing.Type):
 
 
 def document_type(
-    ptype: typing.Type, description: typing.Optional[str] = None
+    ptype: typing.Type[typing.Any], description: typing.Optional[str] = None
 ) -> typing.Dict[str, typing.Any]:
     origin = typing.get_origin(ptype)
     args = typing.get_args(ptype)

--- a/ctf_builder/cmd/schema.py
+++ b/ctf_builder/cmd/schema.py
@@ -1,106 +1,56 @@
-import abc
 import argparse
 import dataclasses
-import enum
-import json
+import glob
+import os
+import os.path
 import typing
 
-from ..config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
-from ..schema import Track, Path
+from ..error import LibError
+from ..schema import Track
 
-from .common import CliContext
-
-ATOM_TYPES = {str: "string", int: "integer", float: "number", bool: "boolean"}
+from .common import cli_challenge_wrapper, WrapContext, CliContext
 
 
 @dataclasses.dataclass(frozen=True)
 class Args:
-    output: typing.Union[str, typing.TextIO] = dataclasses.field(default="schema.json")
+    challenge: typing.Sequence[str] = dataclasses.field(default_factory=list)
 
 
-def is_optional(ptype: typing.Type):
-    origin = typing.get_origin(ptype)
-    args = typing.get_args(ptype)
-
-    return origin == typing.Union and len(args) == 2 and args[1] == type(None)
+@dataclasses.dataclass(frozen=True)
+class Context(WrapContext):
+    pass
 
 
-def document_type(
-    ptype: typing.Type, description: typing.Optional[str] = None
-) -> typing.Dict[str, typing.Any]:
-    origin = typing.get_origin(ptype)
-    args = typing.get_args(ptype)
-
-    out: typing.Dict[str, typing.Any]
-    if is_optional(ptype):
-        return document_type(args[0], description)
-    elif origin == dict:
-        out = {
-            "type": "object",
-            "patternProperties": {"^[a-zA-Z0-9_]+$": document_type(args[1])},
-        }
-    elif origin == list:
-        out = {"type": "array", "items": document_type(args[0])}
-    elif ptype in ATOM_TYPES:
-        out = {"type": ATOM_TYPES[ptype]}
-    elif ptype.__base__ == abc.ABC:
-        subclasses = ptype.__subclasses__()
-        values = [document_type(subclass) for subclass in subclasses]
-
-        for subclass, obj in zip(subclasses, values):
-            name = subclass.__name__[len(ptype.__name__) :].lower()
-
-            obj["required"] = [CLASS_TYPE_FIELD, *obj["required"]]
-            obj["properties"] = {
-                CLASS_TYPE_FIELD: {
-                    "description": CLASS_TYPE_COMMENT,
-                    "type": "string",
-                    "enum": [name],
-                },
-                **obj["properties"],
-            }
-
-        out = {"type": "object", "oneOf": values}
-    elif ptype.__base__ == Path:
-        out = {
-            "type": "string",
-        }
-    elif ptype.__base__ == enum.Enum:
-        out = {"type": "string", "enum": [e.value for e in ptype]}
-    else:
-        properties = {}
-        required = []
-        for field in dataclasses.fields(ptype):
-            if (
-                not is_optional(field.type)
-                and isinstance(field.default, dataclasses._MISSING_TYPE)
-                and isinstance(field.default_factory, dataclasses._MISSING_TYPE)
-            ):
-                required.append(field.name)
-
-            properties[field.name] = document_type(
-                field.type, field.metadata.get(COMMENT_FIELD_NAME)
-            )
-
-        out = {"type": "object", "required": required, "properties": properties}
-
-    if description is not None:
-        out = {"description": description, **out}
-
-    return out
+def schema(track: Track, context: Context) -> typing.Sequence[LibError]:
+    return []
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
-    parser.add_argument("-o", "--output", help="Output file", default="schema.json")
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
+    challenge_directory = os.path.join(root_directory, "challenges")
+
+    challenges = [file for file in glob.glob("*", root_dir=challenge_directory)]
+
+    parser.add_argument(
+        "-c",
+        "--challenge",
+        action="append",
+        choices=challenges,
+        help="Name of challenge",
+        default=[],
+    )
 
 
 def cli(args: Args, cli_context: CliContext) -> bool:
-    doc = document_type(Track)
+    context = Context(
+        challenge_path="",
+        error_prefix=[],
+        skip_inactive=False,
+    )
 
-    if isinstance(args.output, str):
-        with open(args.output, "w") as h:
-            json.dump(doc, h, indent=2)
-    else:
-        json.dump(doc, args.output, indent=2)
-
-    return True
+    return cli_challenge_wrapper(
+        root_directory=cli_context.root_directory,
+        challenges=args.challenge,
+        context=context,
+        callback=schema,
+        console=cli_context.console,
+    )

--- a/ctf_builder/cmd/schema.py
+++ b/ctf_builder/cmd/schema.py
@@ -14,7 +14,7 @@ ATOM_TYPES = {str: "string", int: "integer", float: "number", bool: "boolean"}
 
 @dataclasses.dataclass(frozen=True)
 class Args:
-    output: str
+    output: typing.Union[str, typing.TextIO] = dataclasses.field(default="schema.json")
 
 
 def is_optional(ptype: typing.Type):
@@ -94,7 +94,12 @@ def cli_args(parser: argparse.ArgumentParser, root_directory: str):
 
 
 def cli(args: Args, cli_context: CliContext) -> bool:
-    with open(args.output, "w") as h:
-        json.dump(document_type(Track), h, indent=2)
+    doc = document_type(Track)
+
+    if isinstance(args.output, str):
+        with open(args.output, "w") as h:
+            json.dump(doc, h, indent=2)
+    else:
+        json.dump(doc, args.output, indent=2)
 
     return True

--- a/ctf_builder/cmd/schema.py
+++ b/ctf_builder/cmd/schema.py
@@ -7,8 +7,7 @@ import typing
 
 from ..error import LibError
 from ..schema import Track
-
-from .common import cli_challenge_wrapper, WrapContext, CliContext
+from .common import CliContext, WrapContext, cli_challenge_wrapper
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/schema.py
+++ b/ctf_builder/cmd/schema.py
@@ -5,6 +5,7 @@ import enum
 import json
 import typing
 
+from ..config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
 from ..schema import Track, Path
 
 from .common import CliContext
@@ -49,10 +50,10 @@ def document_type(
         for subclass, obj in zip(subclasses, values):
             name = subclass.__name__[len(ptype.__name__) :].lower()
 
-            obj["required"] = ["$type", *obj["required"]]
+            obj["required"] = [CLASS_TYPE_FIELD, *obj["required"]]
             obj["properties"] = {
-                "$type": {
-                    "description": "Class type selector",
+                CLASS_TYPE_FIELD: {
+                    "description": CLASS_TYPE_COMMENT,
                     "type": "string",
                     "enum": [name],
                 },
@@ -78,7 +79,7 @@ def document_type(
                 required.append(field.name)
 
             properties[field.name] = document_type(
-                field.type, field.metadata.get("comment")
+                field.type, field.metadata.get(COMMENT_FIELD_NAME)
             )
 
         out = {"type": "object", "required": required, "properties": properties}

--- a/ctf_builder/cmd/start.py
+++ b/ctf_builder/cmd/start.py
@@ -8,7 +8,7 @@ import typing
 import docker
 import docker.models.networks
 
-from ..build import DeployContext, BuildDeployer
+from ..build.deployer import DeployContext, BuildDeployer
 from ..config import (
     CHALLENGE_MAX_PORTS,
     CHALLENGE_BASE_PORT,
@@ -72,7 +72,7 @@ def start(track: Track, context: Context) -> typing.Sequence[LibError]:
     return errors
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     challenge_directory = os.path.join(root_directory, "challenges")
 
     challenges = [file for file in glob.glob("*", root_dir=challenge_directory)]

--- a/ctf_builder/cmd/start.py
+++ b/ctf_builder/cmd/start.py
@@ -8,23 +8,22 @@ import typing
 import docker
 import docker.models.networks
 
-from ..build.deployer import DeployContext, BuildDeployer
+from ..build.deployer import BuildDeployer, DeployContext
 from ..config import (
-    CHALLENGE_MAX_PORTS,
     CHALLENGE_BASE_PORT,
+    CHALLENGE_MAX_PORTS,
     DEPLOY_NETWORK,
     NULL_VALUES,
 )
-from ..error import DeployError, SkipError, LibError, print_errors
+from ..error import DeployError, LibError, SkipError, print_errors
 from ..schema import Track
-
 from .common import (
-    cli_challenge_wrapper,
-    WrapContext,
-    port_generator,
-    get_create_network,
-    get_challenge_index,
     CliContext,
+    WrapContext,
+    cli_challenge_wrapper,
+    get_challenge_index,
+    get_create_network,
+    port_generator,
 )
 
 

--- a/ctf_builder/cmd/stop.py
+++ b/ctf_builder/cmd/stop.py
@@ -7,12 +7,11 @@ import typing
 import docker
 import docker.models.networks
 
-from ..build.deployer import DeployContext, BuildDeployer
+from ..build.deployer import BuildDeployer, DeployContext
 from ..config import DEPLOY_NETWORK
-from ..error import DeployError, SkipError, LibError, print_errors
+from ..error import DeployError, LibError, SkipError, print_errors
 from ..schema import Track
-
-from .common import WrapContext, get_network, cli_challenge_wrapper, CliContext
+from .common import CliContext, WrapContext, cli_challenge_wrapper, get_network
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/stop.py
+++ b/ctf_builder/cmd/stop.py
@@ -17,8 +17,8 @@ from .common import WrapContext, get_network, cli_challenge_wrapper, CliContext
 
 @dataclasses.dataclass(frozen=True)
 class Args:
-    challenge: typing.Sequence[str]
-    network: typing.Sequence[str]
+    challenge: typing.Sequence[str] = dataclasses.field(default_factory=list)
+    network: typing.Sequence[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/stop.py
+++ b/ctf_builder/cmd/stop.py
@@ -7,7 +7,7 @@ import typing
 import docker
 import docker.models.networks
 
-from ..build import DeployContext, BuildDeployer
+from ..build.deployer import DeployContext, BuildDeployer
 from ..config import DEPLOY_NETWORK
 from ..error import DeployError, SkipError, LibError, print_errors
 from ..schema import Track
@@ -48,7 +48,7 @@ def stop(track: Track, context: Context) -> typing.Sequence[LibError]:
     return errors
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     challenge_directory = os.path.join(root_directory, "challenges")
 
     challenges = [file for file in glob.glob("*", root_dir=challenge_directory)]

--- a/ctf_builder/cmd/test.py
+++ b/ctf_builder/cmd/test.py
@@ -11,12 +11,10 @@ import docker
 from ..build.deployer import BuildDeployer, DeployContext
 from ..build.tester import BuildTester, TestContext
 from ..build.utils import to_docker_tag
-
-from ..config import DEPLOY_SLEEP, DEPLOY_ATTEMPTS
-from ..error import LibError, DeployError
-from ..schema import Track, Deployer
-
-from .common import cli_challenge_wrapper, WrapContext, create_network, CliContext
+from ..config import DEPLOY_ATTEMPTS, DEPLOY_SLEEP
+from ..error import DeployError, LibError
+from ..schema import Deployer, Track
+from .common import CliContext, WrapContext, cli_challenge_wrapper, create_network
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ctf_builder/cmd/test.py
+++ b/ctf_builder/cmd/test.py
@@ -8,8 +8,10 @@ import typing
 
 import docker
 
-from ..build import BuildTester, BuildDeployer, TestContext, DeployContext
+from ..build.deployer import BuildDeployer, DeployContext
+from ..build.tester import BuildTester, TestContext
 from ..build.utils import to_docker_tag
+
 from ..config import DEPLOY_SLEEP, DEPLOY_ATTEMPTS
 from ..error import LibError, DeployError
 from ..schema import Track, Deployer
@@ -125,7 +127,7 @@ def test(track: Track, context: Context) -> typing.Sequence[LibError]:
     return errors
 
 
-def cli_args(parser: argparse.ArgumentParser, root_directory: str):
+def cli_args(parser: argparse.ArgumentParser, root_directory: str) -> None:
     challenge_directory = os.path.join(root_directory, "challenges")
 
     challenges = [file for file in glob.glob("*", root_dir=challenge_directory)]

--- a/ctf_builder/cmd/test.py
+++ b/ctf_builder/cmd/test.py
@@ -19,7 +19,7 @@ from .common import cli_challenge_wrapper, WrapContext, get_create_network, CliC
 
 @dataclasses.dataclass(frozen=True)
 class Args:
-    challenge: typing.Sequence[str]
+    challenge: typing.Sequence[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -117,7 +117,7 @@ def cli_args(parser: argparse.ArgumentParser, root_directory: str):
     )
 
 
-def cli(args, cli_context: CliContext) -> bool:
+def cli(args: Args, cli_context: CliContext) -> bool:
     context = Context(
         challenge_path="",
         error_prefix=[],

--- a/ctf_builder/config.py
+++ b/ctf_builder/config.py
@@ -6,3 +6,5 @@ CHALLENGE_HOST = "localhost"
 DEPLOY_NETWORK = "ctf-builder"
 DEPLOY_ATTEMPTS = 30
 DEPLOY_SLEEP = 1
+
+NULL_VALUES = set([None, "", "none", "None"])

--- a/ctf_builder/config.py
+++ b/ctf_builder/config.py
@@ -8,3 +8,8 @@ DEPLOY_ATTEMPTS = 30
 DEPLOY_SLEEP = 1
 
 NULL_VALUES = set([None, "", "none", "None"])
+
+CLASS_TYPE_COMMENT = "Object type"
+CLASS_TYPE_FIELD = "$type"
+
+COMMENT_FIELD_NAME = "comment"

--- a/ctf_builder/ctfd.py
+++ b/ctf_builder/ctfd.py
@@ -56,7 +56,7 @@ def read_nonce(sess: requests.Session, url: str) -> typing.Optional[str]:
     return match[0] if match else None
 
 
-def read_csrf(sess: requests, url: str) -> typing.Optional[str]:
+def read_csrf(sess: requests.Session, url: str) -> typing.Optional[str]:
     res = sess.get(url)
 
     match = CSRF_RE.findall(res.text)

--- a/ctf_builder/ctfd.py
+++ b/ctf_builder/ctfd.py
@@ -1,8 +1,12 @@
 import dataclasses
+import datetime
+import re
 import requests
 import typing
 
 VERSION = "/api/v1"
+NONCE_RE = re.compile(r"<input id=\"nonce\".+?value=\"(.+?)\">")
+CSRF_RE = re.compile(r"'csrfNonce': \"(.*?)\"")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -42,3 +46,54 @@ class CTFdAPI:
         return requests.delete(
             f"{self.url}{VERSION}{path}", headers=self.__headers(), json=data
         )
+
+
+def read_nonce(sess: requests.Session, url: str) -> typing.Optional[str]:
+    res = sess.get(url)
+
+    match = NONCE_RE.findall(res.text)
+
+    return match[0] if match else None
+
+
+def read_csrf(sess: requests, url: str) -> typing.Optional[str]:
+    res = sess.get(url)
+
+    match = CSRF_RE.findall(res.text)
+
+    return match[0] if match else None
+
+
+def generate_key(
+    url: str, name: str, password: str
+) -> typing.Optional[typing.Tuple[int, str]]:
+    sess = requests.Session()
+
+    nonce = read_nonce(sess, f"{url}/login")
+
+    res = sess.post(
+        f"{url}/login", data={"name": name, "password": password, "nonce": nonce}
+    )
+    if res.status_code != 200:
+        return None
+
+    csrf = read_csrf(sess, f"{url}/settings")
+
+    expiration = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        days=1
+    )
+
+    res = sess.post(
+        f"{url}/api/v1/tokens",
+        headers={"CSRF-Token": csrf},
+        json={
+            "description": "Created via ctf-builder",
+            "expiration": expiration.date().isoformat(),
+        },
+    )
+    if res.status_code != 200:
+        return None
+
+    data = res.json()["data"]
+
+    return data["id"], data["value"]

--- a/ctf_builder/ctfd.py
+++ b/ctf_builder/ctfd.py
@@ -1,0 +1,44 @@
+import dataclasses
+import requests
+import typing
+
+VERSION = "/api/v1"
+
+
+@dataclasses.dataclass(frozen=True)
+class CTFdAPI:
+    url: str
+    api_key: str
+
+    def __headers(self) -> typing.Dict[str, str]:
+        return {"Authorization": f"Token {self.api_key}"}
+
+    def get(self, path: str) -> requests.Response:
+        return requests.get(f"{self.url}{VERSION}{path}", headers=self.__headers())
+
+    def post(self, path: str, data: typing.Dict[str, typing.Any]) -> requests.Response:
+        return requests.post(
+            f"{self.url}{VERSION}{path}", headers=self.__headers(), json=data
+        )
+
+    def post_data(
+        self, path: str, data: typing.Dict[str, typing.Any], files: typing.Any
+    ) -> requests.Response:
+        return requests.post(
+            f"{self.url}{VERSION}{path}",
+            headers=self.__headers(),
+            data=data,
+            files=files,
+        )
+
+    def patch(self, path: str, data: typing.Dict[str, typing.Any]) -> requests.Response:
+        return requests.patch(
+            f"{self.url}{VERSION}{path}", headers=self.__headers(), json=data
+        )
+
+    def delete(
+        self, path: str, data: typing.Dict[str, typing.Any]
+    ) -> requests.Response:
+        return requests.delete(
+            f"{self.url}{VERSION}{path}", headers=self.__headers(), json=data
+        )

--- a/ctf_builder/ctfd.py
+++ b/ctf_builder/ctfd.py
@@ -1,8 +1,10 @@
 import dataclasses
 import datetime
 import re
-import requests
 import typing
+
+import requests
+
 
 VERSION = "/api/v1"
 NONCE_RE = re.compile(r"<input id=\"nonce\".+?value=\"(.+?)\">")

--- a/ctf_builder/error.py
+++ b/ctf_builder/error.py
@@ -3,8 +3,8 @@ import dataclasses
 import datetime
 import typing
 
-import rich.console
 import rich.columns
+import rich.console
 import rich.markup
 import rich.panel
 import rich.text

--- a/ctf_builder/error.py
+++ b/ctf_builder/error.py
@@ -42,6 +42,7 @@ class TestError(LibError):
 class ParseError(LibError):
     path: str
     expected: typing.List[str]
+    comment: typing.Optional[str]
 
 
 @dataclasses.dataclass
@@ -109,8 +110,16 @@ def print_errors(
 
     for error in errors:
         if isinstance(error, ParseError):
+            path = rich.markup.escape(error.path)
+            expected = ", ".join('[blue]' + v + '[/]' for v in error.expected)
+
+            if error.comment:
+                comment = f" [bright_black]({rich.markup.escape(error.comment)})[/]"
+            else:
+                comment = ""
+
             parse_tree.add(
-                f"[red]{rich.markup.escape(error.path)}[/] is not {", ".join('[blue]' + v + '[/]' for v in error.expected)}"
+                f"[red]{path}[/] is not {expected}{comment}"
             )
         elif isinstance(error, (BuildError, DeployError)):
             if isinstance(error, DeployError):

--- a/ctf_builder/error.py
+++ b/ctf_builder/error.py
@@ -111,16 +111,14 @@ def print_errors(
     for error in errors:
         if isinstance(error, ParseError):
             path = rich.markup.escape(error.path)
-            expected = ", ".join('[blue]' + v + '[/]' for v in error.expected)
+            expected = ", ".join(f"[blue]{v}[/]" for v in error.expected)
 
             if error.comment:
                 comment = f" [bright_black]({rich.markup.escape(error.comment)})[/]"
             else:
                 comment = ""
 
-            parse_tree.add(
-                f"[red]{path}[/] is not {expected}{comment}"
-            )
+            parse_tree.add(f"[red]{path}[/] is not {expected}{comment}")
         elif isinstance(error, (BuildError, DeployError)):
             if isinstance(error, DeployError):
                 target_tree = deploy_tree

--- a/ctf_builder/parse.py
+++ b/ctf_builder/parse.py
@@ -3,6 +3,7 @@ import dataclasses
 import enum
 import typing
 
+from .config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
 from .error import ParseError
 from .schema import Track, Path
 
@@ -46,14 +47,19 @@ def __expected(ptype: typing.Type) -> typing.List[str]:
 
 
 def __parse_type(
-    ptype: typing.Any, data: typing.Any, key_path: str = ""
+    ptype: typing.Any,
+    data: typing.Any,
+    key_path: str = "",
+    comment: typing.Optional[str] = None,
 ) -> typing.Tuple[typing.Optional[typing.Any], typing.Sequence[ParseError]]:
     origin = typing.get_origin(ptype)
     args = typing.get_args(ptype)
 
     if origin == typing.Union and len(args) == 2 and args[1] == type(None):
         # typing.Optional[...]
-        return __parse_type(args[0], data, key_path)
+        return __parse_type(
+            ptype=args[0], data=data, key_path=key_path, comment=comment
+        )
 
     errors: typing.List[ParseError] = []
     if origin == dict:
@@ -61,114 +67,134 @@ def __parse_type(
 
         assert args[0] == str, "Only str keys are supported"
 
-        if not isinstance(data, dict):
-            return None, [ParseError(key_path, __expected(ptype))]
+        if isinstance(data, dict):
+            dict_output: typing.Dict[str, typing.Any] = {}
+            for k, v in data.items():
+                if not isinstance(k, str):
+                    continue
 
-        dict_output: typing.Dict[str, typing.Any] = {}
-        for k, v in data.items():
-            if not isinstance(k, str):
-                continue
+                d, err = __parse_type(args[1], v, f"{key_path}.{k}")
 
-            d, err = __parse_type(args[1], v, f"{key_path}.{k}")
+                if err:
+                    errors += err
+                else:
+                    dict_output[k] = d
 
-            if err:
-                errors += err
-            else:
-                dict_output[k] = d
+            return dict_output, errors
 
-        return dict_output, errors
     elif origin == list:
         # typing.List[...]
 
-        if not isinstance(data, list):
-            return None, [ParseError(key_path, __expected(ptype))]
+        if isinstance(data, list):
+            list_output = []
+            for i, v in enumerate(data):
+                d, err = __parse_type(args[0], v, f"{key_path}.{i}")
 
-        list_output = []
-        for i, v in enumerate(data):
-            d, err = __parse_type(args[0], v, f"{key_path}.{i}")
+                if err:
+                    errors += err
+                else:
+                    list_output.append(d)
 
-            if err:
-                errors += err
-            else:
-                list_output.append(d)
+            return list_output, errors
 
-        return list_output, errors
     elif ptype == float:
+        # float
+
         if isinstance(data, float):
             return data, []
         elif isinstance(data, int):
             return float(data), []
-        else:
-            return None, [ParseError(key_path, __expected(ptype))]
+
     elif ptype in ATOM_TYPES:
-        if not isinstance(data, ptype):
-            return None, [ParseError(key_path, __expected(ptype))]
+        # str, int, bool
 
-        return data, []
+        if isinstance(data, ptype):
+            return data, []
+
     elif ptype.__base__ == Path:
-        if not isinstance(data, str):
-            return None, [ParseError(key_path, __expected(ptype))]
+        # Path subclass
 
-        return ptype(data), []
+        if isinstance(data, str):
+            return ptype(data), []
+
     elif ptype.__base__ == enum.Enum:
+        # enum.Enum subclass
+
         try:
             return ptype(data), []
         except ValueError:
-            return None, [ParseError(key_path, __expected(ptype))]
+            pass
+
     elif dataclasses.is_dataclass(ptype):
-        if not isinstance(data, dict):
-            return None, [ParseError(key_path, __expected(ptype))]
+        # dataclasses.dataclass
 
-        if ptype.__base__ == abc.ABC:
-            tname = data.get("$type")
-            if not isinstance(tname, str):
-                return None, [ParseError(f"{key_path}.$type", __expected(str))]
-
-            parent = ptype
-
-            next_ptype = __get_subclass_from_name(ptype, tname)
-            if next_ptype is None:
-                return None, [
-                    ParseError(f"{key_path}.$type", __get_subclass_names(parent))
-                ]
-            ptype = next_ptype
-
-        type_fields = {}
-        for data_field in dataclasses.fields(ptype):
-            value = data.get(data_field.name)
-            if value is None:
-                if not isinstance(data_field.default, dataclasses._MISSING_TYPE):
-                    d, err = data_field.default, []
-                elif not isinstance(
-                    data_field.default_factory, dataclasses._MISSING_TYPE
-                ):
-                    d, err = data_field.default_factory(), []
-                else:
-                    d, err = None, [
+        if isinstance(data, dict):
+            if ptype.__base__ == abc.ABC:
+                tname = data.get(CLASS_TYPE_FIELD)
+                if not isinstance(tname, str):
+                    return None, [
                         ParseError(
-                            f"{key_path}.{data_field.name}", __expected(data_field.type)
+                            path=f"{key_path}.{CLASS_TYPE_FIELD}",
+                            expected=__expected(str),
+                            comment=CLASS_TYPE_COMMENT,
                         )
                     ]
-            else:
-                d, err = __parse_type(
-                    data_field.type, value, f"{key_path}.{data_field.name}"
-                )
 
-            if err:
-                errors += err
-            else:
-                type_fields[data_field.name] = d
+                parent = ptype
 
-        if errors:
-            return None, errors
+                next_ptype = __get_subclass_from_name(ptype, tname)
+                if next_ptype is None:
+                    return None, [
+                        ParseError(
+                            path=f"{key_path}.{CLASS_TYPE_FIELD}",
+                            expected=__get_subclass_names(parent),
+                            comment=CLASS_TYPE_COMMENT,
+                        )
+                    ]
+                ptype = next_ptype
 
-        return ptype(**type_fields), []
+            type_fields = {}
+            for data_field in dataclasses.fields(ptype):
+                if data_field.name in data:
+                    d, err = __parse_type(
+                        ptype=data_field.type,
+                        data=data[data_field.name],
+                        key_path=f"{key_path}.{data_field.name}",
+                        comment=data_field.metadata.get(COMMENT_FIELD_NAME),
+                    )
+                elif isinstance(
+                    data_field.default, dataclasses._MISSING_TYPE
+                ) and isinstance(data_field.default_factory, dataclasses._MISSING_TYPE):
+                    d, err = None, [
+                        ParseError(
+                            path=f"{key_path}.{data_field.name}",
+                            expected=__expected(data_field.type),
+                            comment=comment,
+                        )
+                    ]
+                else:
+                    continue
+
+                if err:
+                    errors += err
+                else:
+                    type_fields[data_field.name] = d
+
+            if errors:
+                return None, errors
+
+            return ptype(**type_fields), []
+
     else:
         assert False, f"unsupported {ptype}"
 
+    return None, [
+        ParseError(path=key_path, expected=__expected(ptype), comment=comment)
+    ]
+
 
 def parse_track(
-    data: typing.Dict,
+    data: typing.Dict[str, typing.Any],
 ) -> typing.Tuple[typing.Optional[Track], typing.Sequence[ParseError]]:
     if data is None:
         return None, [ParseError("", __expected(Track))]

--- a/ctf_builder/parse.py
+++ b/ctf_builder/parse.py
@@ -23,7 +23,7 @@ def __get_subclass_from_name(
     return None
 
 
-def __get_subclass_names(target: typing.Type) -> typing.List[str]:
+def __get_subclass_names(target: typing.Type[typing.Any]) -> typing.List[str]:
     self_name = target.__name__
 
     names = []
@@ -33,7 +33,7 @@ def __get_subclass_names(target: typing.Type) -> typing.List[str]:
     return names
 
 
-def __expected(ptype: typing.Type) -> typing.List[str]:
+def __expected(ptype: typing.Type[typing.Any]) -> typing.List[str]:
     if ptype in ATOM_TYPES:
         return [ptype.__name__]
     elif typing.get_origin(ptype) == list:

--- a/ctf_builder/parse.py
+++ b/ctf_builder/parse.py
@@ -3,9 +3,10 @@ import dataclasses
 import enum
 import typing
 
-from .config import CLASS_TYPE_COMMENT, COMMENT_FIELD_NAME, CLASS_TYPE_FIELD
+from .config import CLASS_TYPE_COMMENT, CLASS_TYPE_FIELD, COMMENT_FIELD_NAME
 from .error import ParseError
-from .schema import Track, Path
+from .schema import Path, Track
+
 
 SUBCLASS = typing.TypeVar("SUBCLASS")
 ATOM_TYPES = (str, int, float, bool)

--- a/ctf_builder/schema.py
+++ b/ctf_builder/schema.py
@@ -4,13 +4,15 @@ import enum
 import os
 import typing
 
+from .config import COMMENT_FIELD_NAME
+
 
 def _meta_comment(comment: str) -> typing.Dict[str, str]:
     """
     Applies a comment to dataclasses.field to be used in documentation.
     """
 
-    return {"comment": comment}
+    return {COMMENT_FIELD_NAME: comment}
 
 
 @dataclasses.dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-include = '(ctf_builder|tests|sample)/.*\.py$'
+include = '(ctf_builder|sample|tests)/.*\.py$'
 exclude = '__pycache__|\.mypy_cache|\.pytest_cache|\.venv|build/lib'
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 include = '(ctf_builder|sample|tests)/.*\.py$'
 exclude = '__pycache__|\.mypy_cache|\.pytest_cache|\.venv|build/lib'
 
+[tool.isort]
+profile = "black"
+known_first_party = "ctf_builder"
+indent = 4
+lines_after_imports = 2
+
 [tool.mypy]
 files = ["ctf_builder", "tests"]
 exclude = ["^build/", "^sample/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+include = '(ctf_builder|tests|sample)/.*\.py$'
+exclude = '__pycache__|\.mypy_cache|\.pytest_cache|\.venv|build/lib'
+
+[tool.mypy]
+files = ["ctf_builder", "tests"]
+exclude = ["^build/", "^sample/"]
+ignore_missing_imports = true
+strict = true

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,2 +1,3 @@
 /ctfd/teams.out.json
+/doc
 /schema.json

--- a/sample/challenges/deploy/challenge.json
+++ b/sample/challenges/deploy/challenge.json
@@ -78,7 +78,6 @@
       "healthcheck": {
         "test": "netstat -ltn | grep -c 9001",
         "retries": 3,
-        "start_period": 0,
         "interval": 0.5,
         "timeout": 1.5
       }

--- a/sample/challenges/deploy/challenge.json
+++ b/sample/challenges/deploy/challenge.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../schema.json",
+  "$schema": "../../doc/challenge.json",
   "name": "Deploy",
   "active": true,
   "challenges": [

--- a/sample/challenges/multi-deploy/challenge.json
+++ b/sample/challenges/multi-deploy/challenge.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../schema.json",
+  "$schema": "../../doc/challenge.json",
   "name": "Multiple Deploy",
   "tag": "multi-deploy",
   "active": true,

--- a/sample/challenges/multi-deploy/challenge.json
+++ b/sample/challenges/multi-deploy/challenge.json
@@ -74,7 +74,6 @@
       "healthcheck": {
         "test": "netstat -ltn | grep -c 9001",
         "retries": 3,
-        "start_period": 0,
         "interval": 0.5,
         "timeout": 1.5
       }

--- a/sample/challenges/static/challenge.json
+++ b/sample/challenges/static/challenge.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../schema.json",
+  "$schema": "../../doc/challenge.json",
   "name": "Static",
   "active": true,
   "challenges": [

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-black **/*.py
+black .

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+isort .
 black .

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+black **/*.py

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-black --check **/*.py || exit 1
-mypy --disable-error-code=import-untyped -p ctf_builder -p tests || exit 1
-pytest || exit 1
+black --check . || exit 1
+mypy . || exit 1
+pytest . || exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+black --check **/*.py || exit 1
+mypy --disable-error-code=import-untyped -p ctf_builder -p tests || exit 1
+pytest || exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+isort --check . || exit 1
 black --check . || exit 1
 mypy . || exit 1
 pytest . || exit 1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-import setuptools
 import os.path
+
+import setuptools
+
 
 current_directory = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(current_directory, "README.md"), encoding="utf-8") as h:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ package_name = "ctf_builder"
 
 setuptools.setup(
     name=package_name,
-    version="0.0.3",
+    version="0.0.4",
     license="MIT",
     author="Alexandre Lavoie",
     author_email="alexandre.lavoie00@gmail.com",

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -1,0 +1,23 @@
+import os.path
+
+import docker
+
+import rich.console
+
+from ctf_builder.cmd.common import CliContext
+
+from ctf_builder.cmd.build import cli, Args
+
+
+def test():
+    root_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
+    )
+
+    context = CliContext(
+        root_directory=root_directory,
+        docker_client=docker.from_env(),
+        console=rich.console.Console(quiet=True),
+    )
+
+    assert cli(cli_context=context, args=Args(challenge=[]))

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -2,12 +2,11 @@ import os.path
 import typing
 
 import docker
-
 import rich.console
 
+from ctf_builder.cmd.build import Args, cli
 from ctf_builder.cmd.common import CliContext
 
-from ctf_builder.cmd.build import cli, Args
 
 TEST_CHALLENGES: typing.List[str] = []
 

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -12,7 +12,7 @@ from ctf_builder.cmd.build import cli, Args
 TEST_CHALLENGES: typing.List[str] = []
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -1,4 +1,5 @@
 import os.path
+import typing
 
 import docker
 
@@ -7,6 +8,8 @@ import rich.console
 from ctf_builder.cmd.common import CliContext
 
 from ctf_builder.cmd.build import cli, Args
+
+TEST_CHALLENGES: typing.List[str] = []
 
 
 def test():
@@ -20,4 +23,4 @@ def test():
         console=rich.console.Console(quiet=True),
     )
 
-    assert cli(cli_context=context, args=Args(challenge=[]))
+    assert cli(cli_context=context, args=Args(challenge=TEST_CHALLENGES))

--- a/tests/integration/test_ctfd.py
+++ b/tests/integration/test_ctfd.py
@@ -6,21 +6,19 @@ import typing
 
 import docker
 import docker.models.containers
-
 import rich.console
 
+from ctf_builder.cmd.build import Args as BuildArgs
+from ctf_builder.cmd.build import cli as build_cli
+from ctf_builder.cmd.common import CliContext
+from ctf_builder.cmd.ctfd.challenges import Args as ChallengesArgs
+from ctf_builder.cmd.ctfd.challenges import cli as challenges_cli
+from ctf_builder.cmd.ctfd.setup import Args as SetupArgs
+from ctf_builder.cmd.ctfd.setup import cli as setup_cli
+from ctf_builder.cmd.ctfd.teams import Args as TeamsArgs
+from ctf_builder.cmd.ctfd.teams import cli as teams_cli
 from ctf_builder.config import CHALLENGE_BASE_PORT
 from ctf_builder.ctfd import generate_key
-from ctf_builder.cmd.common import CliContext
-
-from ctf_builder.cmd.build import cli as build_cli, Args as BuildArgs
-
-from ctf_builder.cmd.ctfd.setup import cli as setup_cli, Args as SetupArgs
-from ctf_builder.cmd.ctfd.teams import cli as teams_cli, Args as TeamsArgs
-from ctf_builder.cmd.ctfd.challenges import (
-    cli as challenges_cli,
-    Args as ChallengesArgs,
-)
 
 
 TEST_NAME = "test"

--- a/tests/integration/test_ctfd.py
+++ b/tests/integration/test_ctfd.py
@@ -31,7 +31,7 @@ TEST_URL = f"http://localhost:{TEST_PORT}/"
 TEST_CHALLENGES: typing.List[str] = []
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_ctfd.py
+++ b/tests/integration/test_ctfd.py
@@ -119,5 +119,3 @@ def test():
         )
     finally:
         container.remove(force=True)
-
-    # assert cli(cli_context=context, args=Args(challenge=[]))

--- a/tests/integration/test_ctfd.py
+++ b/tests/integration/test_ctfd.py
@@ -1,0 +1,123 @@
+import io
+import json
+import os.path
+import time
+import typing
+
+import docker
+import docker.models.containers
+
+import rich.console
+
+from ctf_builder.config import CHALLENGE_BASE_PORT
+from ctf_builder.ctfd import generate_key
+from ctf_builder.cmd.common import CliContext
+
+from ctf_builder.cmd.build import cli as build_cli, Args as BuildArgs
+
+from ctf_builder.cmd.ctfd.setup import cli as setup_cli, Args as SetupArgs
+from ctf_builder.cmd.ctfd.teams import cli as teams_cli, Args as TeamsArgs
+from ctf_builder.cmd.ctfd.challenges import (
+    cli as challenges_cli,
+    Args as ChallengesArgs,
+)
+
+
+TEST_NAME = "test"
+TEST_PASSWORD = "test"
+TEST_EMAIL = "test@ctf.com"
+TEST_PORT = 9876
+TEST_URL = f"http://localhost:{TEST_PORT}/"
+TEST_CHALLENGES: typing.List[str] = []
+
+
+def test():
+    root_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
+    )
+
+    context = CliContext(
+        root_directory=root_directory,
+        docker_client=docker.from_env(),
+        console=rich.console.Console(quiet=True),
+    )
+
+    # Create a CTFd container
+    container: docker.models.containers.Container = (
+        context.docker_client.containers.run(
+            image="ctfd/ctfd",
+            ports={"8000": TEST_PORT},
+            detach=True,
+            remove=True,
+            healthcheck={
+                "test": "python -c \"import requests; requests.get('http://localhost:8000/')\" || exit 1",
+                "interval": 1_000_000_000,
+                "timeout": 1_000_000_000,
+                "retries": 10,
+                "start_period": 1_000_000_000,
+            },
+        )
+    )
+
+    try:
+        # Wait for container to be healthy
+        for _ in range(40):
+            container.reload()
+
+            if container.health == "healthy":
+                break
+
+            time.sleep(0.5)
+        else:
+            assert False, "Container failed to start"
+
+        # Setup CTFd
+        assert setup_cli(
+            cli_context=context,
+            args=SetupArgs(
+                name=TEST_NAME,
+                email=TEST_EMAIL,
+                password=TEST_PASSWORD,
+                file=os.path.join(context.root_directory, "ctfd", "setup.json"),
+                url=TEST_URL,
+            ),
+        )
+
+        # Generate a token for admin account
+        token = generate_key(TEST_URL, name=TEST_NAME, password=TEST_PASSWORD)
+        assert token, "Failed to generate api key"
+
+        api_key = token[1]
+
+        # Deploy teams
+        teams_output = io.StringIO()
+        assert teams_cli(
+            cli_context=context,
+            args=TeamsArgs(
+                api_key=api_key,
+                file=os.path.join(context.root_directory, "ctfd", "teams.json"),
+                output=teams_output,
+                url=TEST_URL,
+            ),
+        )
+        teams_output.seek(0)
+
+        assert json.load(teams_output)
+
+        # Build challenges
+        assert build_cli(cli_context=context, args=BuildArgs(challenge=TEST_CHALLENGES))
+
+        # Deploy challenges
+        assert challenges_cli(
+            cli_context=context,
+            args=ChallengesArgs(
+                api_key=api_key,
+                url=TEST_URL,
+                port=CHALLENGE_BASE_PORT,
+                challenge=TEST_CHALLENGES,
+            ),
+        )
+    finally:
+        container.remove(force=True)
+
+    # assert cli(cli_context=context, args=Args(challenge=[]))

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -1,4 +1,5 @@
 import os.path
+import typing
 import uuid
 
 import docker
@@ -10,6 +11,8 @@ from ctf_builder.cmd.common import CliContext
 
 from ctf_builder.cmd.start import cli as start_cli, Args as StartArgs
 from ctf_builder.cmd.stop import cli as stop_cli, Args as StopArgs
+
+TEST_CHALLENGES: typing.List[str] = []
 
 
 def test():
@@ -29,7 +32,7 @@ def test():
         assert start_cli(
             cli_context=context,
             args=StartArgs(
-                challenge=[],
+                challenge=TEST_CHALLENGES,
                 ip=[None],
                 network=[network],
                 port=CHALLENGE_BASE_PORT,
@@ -38,5 +41,6 @@ def test():
         )
     finally:
         assert stop_cli(
-            cli_context=context, args=StopArgs(challenge=[], network=[network])
+            cli_context=context,
+            args=StopArgs(challenge=TEST_CHALLENGES, network=[network]),
         )

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -15,7 +15,7 @@ from ctf_builder.cmd.stop import cli as stop_cli, Args as StopArgs
 TEST_CHALLENGES: typing.List[str] = []
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -3,14 +3,15 @@ import typing
 import uuid
 
 import docker
-
 import rich.console
 
-from ctf_builder.config import CHALLENGE_BASE_PORT
 from ctf_builder.cmd.common import CliContext
+from ctf_builder.cmd.start import Args as StartArgs
+from ctf_builder.cmd.start import cli as start_cli
+from ctf_builder.cmd.stop import Args as StopArgs
+from ctf_builder.cmd.stop import cli as stop_cli
+from ctf_builder.config import CHALLENGE_BASE_PORT
 
-from ctf_builder.cmd.start import cli as start_cli, Args as StartArgs
-from ctf_builder.cmd.stop import cli as stop_cli, Args as StopArgs
 
 TEST_CHALLENGES: typing.List[str] = []
 

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -40,7 +40,13 @@ def test():
             ),
         )
     finally:
-        assert stop_cli(
-            cli_context=context,
-            args=StopArgs(challenge=TEST_CHALLENGES, network=[network]),
-        )
+        try:
+            assert stop_cli(
+                cli_context=context,
+                args=StopArgs(challenge=TEST_CHALLENGES, network=[network]),
+            )
+        finally:
+            try:
+                context.docker_client.api.remove_network(network)
+            except:
+                pass

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -1,0 +1,42 @@
+import os.path
+import uuid
+
+import docker
+
+import rich.console
+
+from ctf_builder.config import CHALLENGE_BASE_PORT
+from ctf_builder.cmd.common import CliContext
+
+from ctf_builder.cmd.start import cli as start_cli, Args as StartArgs
+from ctf_builder.cmd.stop import cli as stop_cli, Args as StopArgs
+
+
+def test():
+    root_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
+    )
+
+    context = CliContext(
+        root_directory=root_directory,
+        docker_client=docker.from_env(),
+        console=rich.console.Console(quiet=True),
+    )
+
+    network = str(f"ctf-builder_test_{uuid.uuid4()}")
+
+    try:
+        assert start_cli(
+            cli_context=context,
+            args=StartArgs(
+                challenge=[],
+                ip=[None],
+                network=[network],
+                port=CHALLENGE_BASE_PORT,
+                detach=True,
+            ),
+        )
+    finally:
+        assert stop_cli(
+            cli_context=context, args=StopArgs(challenge=[], network=[network])
+        )

--- a/tests/integration/test_documentation.py
+++ b/tests/integration/test_documentation.py
@@ -1,5 +1,6 @@
+import json
 import os.path
-import typing
+import tempfile
 
 import docker
 
@@ -7,9 +8,7 @@ import rich.console
 
 from ctf_builder.cmd.common import CliContext
 
-from ctf_builder.cmd.schema import cli, Args
-
-TEST_CHALLENGES: typing.List[str] = []
+from ctf_builder.cmd.documentation import cli, Args
 
 
 def test():
@@ -23,4 +22,8 @@ def test():
         console=rich.console.Console(quiet=True),
     )
 
-    assert cli(cli_context=context, args=Args(challenge=TEST_CHALLENGES))
+    with tempfile.TemporaryDirectory() as temp_dir:
+        assert cli(cli_context=context, args=Args(output=temp_dir))
+
+        with open(os.path.join(temp_dir, "challenge.json")) as h:
+            assert json.load(h)

--- a/tests/integration/test_documentation.py
+++ b/tests/integration/test_documentation.py
@@ -11,7 +11,7 @@ from ctf_builder.cmd.common import CliContext
 from ctf_builder.cmd.documentation import cli, Args
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_documentation.py
+++ b/tests/integration/test_documentation.py
@@ -3,12 +3,10 @@ import os.path
 import tempfile
 
 import docker
-
 import rich.console
 
 from ctf_builder.cmd.common import CliContext
-
-from ctf_builder.cmd.documentation import cli, Args
+from ctf_builder.cmd.documentation import Args, cli
 
 
 def test() -> None:

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,0 +1,29 @@
+import io
+import json
+import os.path
+
+import docker
+
+import rich.console
+
+from ctf_builder.cmd.common import CliContext
+
+from ctf_builder.cmd.schema import cli, Args
+
+
+def test():
+    root_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
+    )
+
+    context = CliContext(
+        root_directory=root_directory,
+        docker_client=docker.from_env(),
+        console=rich.console.Console(quiet=True),
+    )
+
+    out_file = io.StringIO()
+    assert cli(cli_context=context, args=Args(output=out_file))
+    out_file.seek(0)
+
+    json.load(out_file)

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2,12 +2,11 @@ import os.path
 import typing
 
 import docker
-
 import rich.console
 
 from ctf_builder.cmd.common import CliContext
+from ctf_builder.cmd.schema import Args, cli
 
-from ctf_builder.cmd.schema import cli, Args
 
 TEST_CHALLENGES: typing.List[str] = []
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -12,7 +12,7 @@ from ctf_builder.cmd.schema import cli, Args
 TEST_CHALLENGES: typing.List[str] = []
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_test.py
+++ b/tests/integration/test_test.py
@@ -1,0 +1,23 @@
+import os.path
+
+import docker
+
+import rich.console
+
+from ctf_builder.cmd.common import CliContext
+
+from ctf_builder.cmd.test import cli, Args
+
+
+def test():
+    root_directory = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
+    )
+
+    context = CliContext(
+        root_directory=root_directory,
+        docker_client=docker.from_env(),
+        console=rich.console.Console(quiet=True),
+    )
+
+    assert cli(cli_context=context, args=Args(challenge=[]))

--- a/tests/integration/test_test.py
+++ b/tests/integration/test_test.py
@@ -2,12 +2,10 @@ import os.path
 import typing
 
 import docker
-
 import rich.console
 
 from ctf_builder.cmd.common import CliContext
-
-from ctf_builder.cmd.test import cli, Args
+from ctf_builder.cmd.test import Args, cli
 
 
 TEST_CHALLENGES: typing.List[str] = []

--- a/tests/integration/test_test.py
+++ b/tests/integration/test_test.py
@@ -13,7 +13,7 @@ from ctf_builder.cmd.test import cli, Args
 TEST_CHALLENGES: typing.List[str] = []
 
 
-def test():
+def test() -> None:
     root_directory = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", "..", "sample"
     )

--- a/tests/integration/test_test.py
+++ b/tests/integration/test_test.py
@@ -1,4 +1,5 @@
 import os.path
+import typing
 
 import docker
 
@@ -7,6 +8,9 @@ import rich.console
 from ctf_builder.cmd.common import CliContext
 
 from ctf_builder.cmd.test import cli, Args
+
+
+TEST_CHALLENGES: typing.List[str] = []
 
 
 def test():
@@ -20,4 +24,4 @@ def test():
         console=rich.console.Console(quiet=True),
     )
 
-    assert cli(cli_context=context, args=Args(challenge=[]))
+    assert cli(cli_context=context, args=Args(challenge=TEST_CHALLENGES))


### PR DESCRIPTION
## Features

Moved `schema` to `doc`, and files are now output to a `/doc` folder.

`schema` now only checks that `challenge.json` is valid.

`ParseError` now also include the comment defined in `schema.py`

## Bug Fix

Networks would not always cleanup for tests, now they should.

Catching `None` network for deployments.

## Dev

Added integration tests.

Added `isort`.

Enabled `strict` mode for `mypy`.

Using `pyproject.toml` to set `isort`, `black`, and `mypy` setting.

Wrapped CTFd calls into CTFdAPI.