### PR TITLE
0.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ ctf start -n team1 -i 192.168.0.2 -n team2 -i 192.168.0.3 ...
 ## ⚓ Kubernetes
 
 ```
-ctf kubernetes build
+ctf k8s build
 ```
 
 Deploys challenges to [Kubernetes](https://kubernetes.io/). This is the most robust way to deploy challenges.

--- a/ctf_builder/cmd/common.py
+++ b/ctf_builder/cmd/common.py
@@ -1,7 +1,7 @@
 import argparse
 import dataclasses
-import glob
 import json
+import os
 import os.path
 import threading
 import time
@@ -109,7 +109,14 @@ def get_challenges(root_directory: str) -> typing.Optional[typing.Sequence[str]]
     if not os.path.isdir(challenge_directory):
         return None
 
-    return [name for name in glob.glob("*", root_dir=challenge_directory)]
+    challenges = []
+    for _, directories, _ in os.walk(challenge_directory):
+        for directory in directories:
+            challenges.append(directory)
+
+        break
+
+    return challenges
 
 
 def get_challenge_index(challenge_path: str) -> int:

--- a/ctf_builder/k8s/models.py
+++ b/ctf_builder/k8s/models.py
@@ -44,7 +44,7 @@ class K8sMatchSelector(pydantic.BaseModel):
     matchLabels: typing.Dict[str, str]
 
 
-K8sDictSelector: typing.TypeAlias = typing.Dict[str, str]
+K8sDictSelector = typing.Dict[str, str]
 
 
 class K8sConfigMap(pydantic.BaseModel):
@@ -241,6 +241,6 @@ class K8sNetworkPolicy(pydantic.BaseModel):
     spec: K8sNetworkPolicySpec
 
 
-K8sKind: typing.TypeAlias = typing.Union[
+K8sKind = typing.Union[
     K8sConfigMap, K8sDeployment, K8sList, K8sNetworkPolicy, K8sPod, K8sService
 ]

--- a/ctf_builder/models/arguments.py
+++ b/ctf_builder/models/arguments.py
@@ -78,6 +78,4 @@ class MapArguments(BaseArguments):
         return self.map
 
 
-Arguments: typing.TypeAlias = typing.Union[
-    EnvFileArguments, ListArguments, MapArguments
-]
+Arguments = typing.Union[EnvFileArguments, ListArguments, MapArguments]

--- a/ctf_builder/models/build/__init__.py
+++ b/ctf_builder/models/build/__init__.py
@@ -2,4 +2,4 @@ import typing
 
 from .docker import BuildDocker
 
-Build: typing.TypeAlias = typing.Union[BuildDocker]
+Build = typing.Union[BuildDocker]

--- a/ctf_builder/models/deploy/__init__.py
+++ b/ctf_builder/models/deploy/__init__.py
@@ -3,4 +3,4 @@ import typing
 from .docker import DeployDocker
 
 
-Deploy: typing.TypeAlias = typing.Union[DeployDocker]
+Deploy = typing.Union[DeployDocker]

--- a/ctf_builder/models/path.py
+++ b/ctf_builder/models/path.py
@@ -41,4 +41,4 @@ class FilePath(pydantic.RootModel[str]):
         return path
 
 
-Path: typing.TypeAlias = typing.Union[DirectoryPath, FilePath]
+Path = typing.Union[DirectoryPath, FilePath]

--- a/ctf_builder/models/port.py
+++ b/ctf_builder/models/port.py
@@ -93,6 +93,4 @@ class WSSPort(BasePort):
         return K8sPortProtocol.TCP
 
 
-Port: typing.TypeAlias = typing.Union[
-    HTTPPort, HTTPSPort, TCPPort, UDPPort, WSPort, WSSPort
-]
+Port = typing.Union[HTTPPort, HTTPSPort, TCPPort, UDPPort, WSPort, WSSPort]

--- a/ctf_builder/models/test/__init__.py
+++ b/ctf_builder/models/test/__init__.py
@@ -3,4 +3,4 @@ import typing
 from .docker import TestDocker
 
 
-Test: typing.TypeAlias = typing.Union[TestDocker]
+Test = typing.Union[TestDocker]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,5 @@
+black
+isort
+mypy
+pytest
+types-requests

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ package_name = "ctf_builder"
 
 setuptools.setup(
     name=package_name,
-    version="0.0.12",
+    version="0.0.13",
     license="MIT",
     author="Alexandre Lavoie",
     author_email="alexandre.lavoie00@gmail.com",


### PR DESCRIPTION
Couple users are still on Python 3.8. This patch version tries to downgrade to support this version upwards (not fully tested but passed the unit tests).

Updated doc to fix `k8s` mention.

Added a `requirements.dev.txt` for development tools.